### PR TITLE
Fix S3 error typo

### DIFF
--- a/db_s3.go
+++ b/db_s3.go
@@ -64,7 +64,7 @@ func (d *DB_S3) Get(key string, ignore_missing bool) ([]byte, error) {
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf(`error while comunicating with S3. %v`, apiErr)
+		return nil, fmt.Errorf(`error while communicating with S3. %v`, apiErr)
 	}
 
 	buf := new(bytes.Buffer)
@@ -102,7 +102,7 @@ func (d *DB_S3) Put(key string, val []byte, ignore_existing bool) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf(`error while comunicating with S3. %v`, err)
+		return fmt.Errorf(`error while communicating with S3. %v`, err)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- fix spelling of "communicating" in S3 `Get` and `Put` errors

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_6872d441d8848320b0247704aaf1bebc